### PR TITLE
fix(movie): use 200 OK instead of 202 Accepted when movie is found

### DIFF
--- a/controller/movie.js
+++ b/controller/movie.js
@@ -41,7 +41,7 @@ router.get("/:movieId", async (req, res) => {
     const movie = await Movie.findById({ _id: req.params.movieId })
       .populate("genre", "name")
       .exec(); // populate the genre associated with the movie
-    if (movie) return res.status(202).json(movie);
+    if (movie) return res.status(200).json(movie);
     return res
       .status(404)
       .json({ error: "The movie you are looking doesn't exist" });


### PR DESCRIPTION
Changed HTTP status code from 202 to 200 when a movie is successfully retrieved.

202 is intended for async processing, while 200 is the correct response for successful GET requests.